### PR TITLE
Fix typos

### DIFF
--- a/content/notebooks/intro-to-pandas.ipynb
+++ b/content/notebooks/intro-to-pandas.ipynb
@@ -2789,7 +2789,7 @@
     "editable": true
    },
    "source": [
-    "Since our index is kind of meaningless right now, let's set it to the _user_id_ using the `set_index` method. By default, `set_index` returns a new DataFrame, so you'll have to specify if you'd like the changes to occur in place.\n",
+    "Since our index is kind of meaningless right now, let's set it to the `user_id` using the `set_index` method. By default, `set_index` returns a new DataFrame, so you'll have to specify if you'd like the changes to occur in place.\n",
     "\n",
     "This has confused me in the past, so look carefully at the code and output below."
    ]
@@ -2857,7 +2857,7 @@
     "editable": true
    },
    "source": [
-    "If you want to modify your existing DataFrame, use the `inplace` parameter. Most DataFrame methods return new a DataFrames, while offering an `inplace` parameter. Note that the `inplace` version might not actually be any more efficint (in terms of speed or memory usage) that the regular version."
+    "If you want to modify your existing DataFrame, use the `inplace` parameter. Most DataFrame methods return new a DataFrames, while offering an `inplace` parameter. Note that the `inplace` version might not actually be any more efficient (in terms of speed or memory usage) than the regular version."
    ]
   },
   {


### PR DESCRIPTION
Great intro to Pandas! I shared it with a couple friends and was going through and caught a couple things:

- fix a couple typos
- change (de-emphasize) `user_id` so that it renders correctly (something about blog's markdown plugin is causing it to render as `_userid`)